### PR TITLE
Add dev.new() for map clicking & 2 typos

### DIFF
--- a/RSVSW/RSVS_classification.Rmd
+++ b/RSVSW/RSVS_classification.Rmd
@@ -238,7 +238,7 @@ dat_all <- data.table::as.data.table(rasterToPoints(s2_rl))
 # Add a column with the id
 dat_all = dat_all <- dat_all %>% mutate(id = row_number())
 
-# Select the id (column 1) and spectral data (columns 3 to 15) from dat_all
+# Select the id (column 15) and spectral data (columns 3 to 14) from dat_all
 dat_all = dat_all[,c(3:15)]
 
 # Create a vector of wavelengths that correspond to the columns of dat_all and include the id column
@@ -645,7 +645,7 @@ rglcm <- glcm(s2_rl[[4]],
 plot(rglcm)
 ```
 
-or we can calculate rotation-invariant texture features. This means that the e textural features are calculated in all 4 directions (0°, 45°, 90° and 135°) and then combined to one rotation-invariant texture. The key for this is the shift parameter.
+or we can calculate rotation-invariant texture features. This means that the textural features are calculated in all 4 directions (0°, 45°, 90° and 135°) and then combined to one rotation-invariant texture. The key for this is the shift parameter.
 
 ```{r}
 # Calculate gray level co-occurrence matrix (GLCM) for the fourth band of the image

--- a/RSVSW/RSVS_classification.Rmd
+++ b/RSVSW/RSVS_classification.Rmd
@@ -154,6 +154,7 @@ Once this is done you can visualize the image and use an interactive clicking fu
 
 ```{r}
 # Plot the data
+dev.new() # In RStudio, the raster::click()/terra::click() functions may result in an offset between the clicked point and the recorded one.
 raster::plotRGB(s2_rl, 2, 3, 4, stretch="lin", scale=5000)
 # Change plotting parameters to better see the points and numbers generated from clicking
 par(col="red", cex=3)
@@ -680,6 +681,7 @@ Therefore, we first have to first estimate the endmember spectra by selecting a 
 
 ```{r}
 # Plot the data
+dev.new() # To avoid offsets between clicked and recorded points
 plotRGB(s2_rl,2,3,4,stretch="lin",scale=5000)
 # change plotting parameters to better see the points and numbers generated from clicking
 par(col="red", cex=3)


### PR DESCRIPTION
- Add `dev.new()` before calling `raster::click()` as in RStudio there may be an offset between the point you click and the one that is recorded. By first calling `dev.new()`, a new window opens for clicking, so that you can click without offset.
- Correct small typo and change "column 1" to "column 15" (which effectively holds the `"id"`)